### PR TITLE
🎨 Palette: Add skip-to-content link and enhance link accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - [Accessibility Gaps in Templates]
+**Learning:** Even when accessibility features (like skip-to-content links) are partially implemented in CSS or JS, they can be missing from the actual HTML templates, leading to a "phantom" feature that doesn't actually benefit users.
+**Action:** Always verify that accessibility hooks defined in stylesheets are correctly anchored in the core layout templates.
+
+## 2025-05-15 - [Generic Link Labels]
+**Learning:** Repetitive "Read More" links without context are a common accessibility hurdle for screen reader users.
+**Action:** Use `aria-label` to provide specific context to generic call-to-action links when they appear in lists or grids.

--- a/_includes/front-page-featured-articles.html
+++ b/_includes/front-page-featured-articles.html
@@ -26,7 +26,7 @@ Front-page featured section: most important articles from _data/important_articl
     <div class="article-item">
       <h4><a href="{{ '/news/' | append: y | append: '/' | append: m | append: '/' | append: d | append: '/' | append: slug | append: '/' | relative_url }}">{{ article.title }}</a></h4>
       <p class="article-date">{{ article.date | date: "%B %d, %Y" }} — {{ article.source }}</p>
-      <a href="{{ '/news/' | append: y | append: '/' | append: m | append: '/' | append: d | append: '/' | append: slug | append: '/' | relative_url }}" class="read-more">Read More →</a>
+      <a href="{{ '/news/' | append: y | append: '/' | append: m | append: '/' | append: d | append: '/' | append: slug | append: '/' | relative_url }}" class="read-more" aria-label="Read more about {{ article.title | escape }}">Read More →</a>
     </div>
     {%- endfor -%}
     {%- if crit and crit.size >= 6 -%}
@@ -53,7 +53,7 @@ Front-page featured section: most important articles from _data/important_articl
     <div class="article-item">
       <h4><a href="{{ '/news/' | append: y | append: '/' | append: m | append: '/' | append: d | append: '/' | append: slug | append: '/' | relative_url }}">{{ article.title }}</a></h4>
       <p class="article-date">{{ article.date | date: "%B %d, %Y" }} — {{ article.source }}</p>
-      <a href="{{ '/news/' | append: y | append: '/' | append: m | append: '/' | append: d | append: '/' | append: slug | append: '/' | relative_url }}" class="read-more">Read More →</a>
+      <a href="{{ '/news/' | append: y | append: '/' | append: m | append: '/' | append: d | append: '/' | append: slug | append: '/' | relative_url }}" class="read-more" aria-label="Read more about {{ article.title | escape }}">Read More →</a>
     </div>
       {%- endfor -%}
     {%- endif -%}

--- a/_includes/home-news.html
+++ b/_includes/home-news.html
@@ -16,7 +16,7 @@
           <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
         </h3>
         <p class="home-news-card__excerpt">{{ post.excerpt | default: post.content | strip_html | truncatewords: 28 }}</p>
-        <a href="{{ post.url | relative_url }}" class="home-news-card__link">Read article →</a>
+        <a href="{{ post.url | relative_url }}" class="home-news-card__link" aria-label="Read article about {{ post.title | escape }}">Read article →</a>
       </article>
       {% endfor %}
     </div>

--- a/_layouts/candidates-root.html
+++ b/_layouts/candidates-root.html
@@ -17,6 +17,7 @@
   {% endif %}
 </head>
 <body class="{{ page.body_class }}">
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <div class="header-top">
       <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -154,6 +154,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}?v={{ site.asset_version }}">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <div class="header-top">
       <div class="container">
@@ -343,7 +344,7 @@
           <h4><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h4>
           <p class="article-date">{{ post.date | date: "%B %d, %Y" }}</p>
           <p class="article-excerpt">{{ post.excerpt | strip_html | truncatewords: 30 }}</p>
-          <a href="{{ post.url | relative_url }}" class="read-more">Read More →</a>
+          <a href="{{ post.url | relative_url }}" class="read-more" aria-label="Read more about {{ post.title | escape }}">Read More →</a>
         </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
This PR introduces two key accessibility improvements to the Central Texas Legal Resource site:

1.  **Skip to Content Link**: A "Skip to content" link has been added to the main layouts. This allows users navigating with keyboards or screen readers to bypass the site header and navigation menu, jumping directly to the main content. The link is visually hidden by default and only appears when it receives focus.
2.  **Descriptive Link Labels**: "Read more" and "Read article" links across the site have been enhanced with `aria-label` attributes that include the title of the article they point to. This ensures that screen reader users can distinguish between multiple links on the page that otherwise have identical text.

These changes were verified by:
- Running a Playwright script to confirm the "Skip to content" link functions and targets `#main-content`.
- Inspecting the generated Jekyll site artifacts to verify the presence of `aria-label` attributes.
- Confirming that the "Skip to content" link is correctly styled (hidden until focus) using the site's existing CSS.


---
*PR created automatically by Jules for task [14312300761207505888](https://jules.google.com/task/14312300761207505888) started by @sweeden-ttu*