### PR TITLE
🎨 Palette: Add "Skip to Content" link for accessibility

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -145,6 +145,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <!-- Google Tag Manager (noscript) -->
   {% if site.gtm_container_id and site.gtm_container_id != "GTM-XXXXXXX" %}
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.gtm_container_id }}"

--- a/_layouts/m3u8downloader.html
+++ b/_layouts/m3u8downloader.html
@@ -186,6 +186,7 @@
   </style>
 </head>
 <body class="m3u8-page">
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <header class="m3u8-header">
     <div class="container">
       <div class="m3u8-logo">M3U8 Downloader</div>
@@ -200,7 +201,7 @@
     </div>
   </header>
 
-  <main class="m3u8-main">
+  <main id="main-content" class="m3u8-main" tabindex="-1">
     <div class="m3u8-content">
       <h1 class="m3u8-title">M3U8 Video Downloader</h1>
       <p class="m3u8-subtitle">The M3U8 downloader requires a browser extension to work. If you have already installed it, please remove the old version and update to the latest version!</p>


### PR DESCRIPTION
💡 What: Added a "Skip to Content" accessibility link to the primary site layouts.
🎯 Why: This allows users navigating with keyboards or screen readers to bypass the site header and navigation menu, jumping directly to the main content. This is a standard accessibility best practice that was missing from several layouts.
♿ Accessibility: Improved keyboard navigation and screen reader support by providing a quick way to reach the main content.
📸 Before/After: The link is visually hidden by default and appears at the top of the page when it receives focus via the Tab key.

---
*PR created automatically by Jules for task [11946116984526542444](https://jules.google.com/task/11946116984526542444) started by @sweeden-ttu*