### PR TITLE
🎨 Palette: Add "Skip to Content" accessibility link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -145,6 +145,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <!-- Google Tag Manager (noscript) -->
   {% if site.gtm_container_id and site.gtm_container_id != "GTM-XXXXXXX" %}
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.gtm_container_id }}"

--- a/_layouts/m3u8downloader.html
+++ b/_layouts/m3u8downloader.html
@@ -186,6 +186,7 @@
   </style>
 </head>
 <body class="m3u8-page">
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <header class="m3u8-header">
     <div class="container">
       <div class="m3u8-logo">M3U8 Downloader</div>
@@ -200,7 +201,7 @@
     </div>
   </header>
 
-  <main class="m3u8-main">
+  <main id="main-content" class="m3u8-main" tabindex="-1">
     <div class="m3u8-content">
       <h1 class="m3u8-title">M3U8 Video Downloader</h1>
       <p class="m3u8-subtitle">The M3U8 downloader requires a browser extension to work. If you have already installed it, please remove the old version and update to the latest version!</p>

--- a/test_cases/palette-verification.spec.ts
+++ b/test_cases/palette-verification.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('skip to content link is present and functional on homepage', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4000/');
+
+  const skipLink = page.locator('a.skip-link');
+  await expect(skipLink).toBeAttached();
+  await expect(skipLink).toHaveAttribute('href', '#main-content');
+  await expect(skipLink).toHaveText('Skip to content');
+
+  // Check if it's the first focusable element
+  await page.keyboard.press('Tab');
+  await expect(skipLink).toBeFocused();
+
+  // Check if main content is focused after clicking
+  await skipLink.click();
+  const mainContent = page.locator('#main-content');
+  await expect(mainContent).toBeFocused();
+});


### PR DESCRIPTION
This PR adds a "Skip to Content" link to the primary layouts. This is a crucial accessibility feature that allows keyboard-only and screen reader users to bypass the navigation menu and jump directly to the main content.

💡 **What:** Added a skip link as the first focusable element in `default.html` and `m3u8downloader.html`.
🎯 **Why:** Improves keyboard accessibility and follows web accessibility best practices.
♿ **Accessibility:** Users can now use `Tab` and `Enter` to jump past header navigation.
✅ **Verified:** Tested on local dev server; automated test added in `test_cases/palette-verification.spec.ts`.

---
*PR created automatically by Jules for task [857459428728572406](https://jules.google.com/task/857459428728572406) started by @sweeden-ttu*