### PR TITLE
Add Mike Russell dossier under courts/146

### DIFF
--- a/_candidates/courts/146/mike_russell.md
+++ b/_candidates/courts/146/mike_russell.md
@@ -1,0 +1,35 @@
+---
+layout: candidate-profile
+title: "Judge Mike Russell"
+candidate_slug: mike_russell
+city: belton
+office: "District Judge, 146th District Court (Candidate)"
+party: "Republican"
+headshot: "/assets/img/candidates/mike-russell.jpg"
+social_media: "https://www.facebook.com/mikerussellforjudge/"
+campaign_url: "https://www.mikerussellforjudge.com/"
+profile_summary: |
+  Judge Mike Russell currently serves as the Judge of the 146th Judicial District Court in Bell County, a position he assumed in January 2025 after winning the Republican primary and running unopposed in the November general election. He replaced retiring Judge Jack Jones.
+
+  ### Academic Background
+  Judge Russell earned his Doctor of Jurisprudence from the **Baylor University School of Law** in 2004. He completed his undergraduate studies at the **University of Texas at Arlington**, where he received a Bachelor of Arts in History in 2000.
+
+  ### Professional History
+  With 20 years of legal experience prior to his election, Judge Russell was a distinguished litigator at Harrell, Stoebner & Russell, P.C. in Temple, Texas. His practice spanned a wide variety of civil matters, including contract, personal injury, trusts and estates, torts, real estate, employment, and family law.
+
+  Notably, Judge Russell has substantial experience with Child Protective Services (CPS) cases and family law, emphasizing the importance of compassion, open-mindedness, and fair rulings when families face difficult situations like removal proceedings.
+
+  ### Platform
+  During his campaign, Judge Russell emphasized the need to address the court's substantial docket backlog. Recognizing the staggering number of civil and family law cases filed in the county, he advocated for instituting standard operating procedures to increase efficiency, particularly highlighting the urgency of temporary order hearings in family cases.
+
+election_results_2026:
+  total: "Incumbent"
+  vote_percent: "N/A"
+  absentee: "N/A"
+  early_voting: "N/A"
+  election_day: "N/A"
+
+office_timeline: |
+  *   **2025–Present:** Judge, 146th District Court
+  *   **2004–2024:** Private Legal Practice (Harrell, Stoebner & Russell, P.C.), Temple
+---


### PR DESCRIPTION
Created the `_candidates/courts/146/mike_russell.md` file using available information online. Includes his academic background, professional history (with a focus on family law and CPS as requested in previous guidelines), platform regarding the docket, social media links, and election results (incumbent/unopposed in the general election after winning the primary).