### PR TITLE
🎨 Palette: Add "Skip to content" link for accessibility

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -152,6 +152,8 @@
   <!-- End Google Tag Manager (noscript) -->
   {% endif %}
 
+  <a href="#main-content" class="skip-link">Skip to content</a>
+
   <header class="site-header">
     <div class="header-top">
       <div class="container">


### PR DESCRIPTION
Added a "Skip to content" link to `_layouts/default.html` to improve accessibility for keyboard and screen reader users. The link is hidden by default and appears on focus, allowing users to skip navigation and go straight to the main content area. Verified with browser automation and visual inspection.

---
*PR created automatically by Jules for task [782751129934002332](https://jules.google.com/task/782751129934002332) started by @sweeden-ttu*