### PR TITLE
🎨 Palette: Improve keyboard accessibility with Skip Link and focus styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -145,6 +145,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <!-- Google Tag Manager (noscript) -->
   {% if site.gtm_container_id and site.gtm_container_id != "GTM-XXXXXXX" %}
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.gtm_container_id }}"

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -57,6 +57,11 @@ body {
   width: 1px;
 }
 
+:focus-visible {
+  outline: 2px solid var(--gold-light);
+  outline-offset: 2px;
+}
+
 h1, h2, h3, h4 {
   font-family: 'Cinzel', 'Times New Roman', serif;
   font-weight: 700;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -57,6 +57,11 @@ body {
   width: 1px;
 }
 
+:focus-visible {
+  outline: 2px solid var(--gold-light);
+  outline-offset: 2px;
+}
+
 h1, h2, h3, h4 {
   font-family: 'Cinzel', 'Times New Roman', serif;
   font-weight: 700;


### PR DESCRIPTION
This PR implements two key micro-UX improvements focused on accessibility:

1.  **Skip to Content Link**: Added a "Skip to content" link as the first element in the `default.html` layout. This allows keyboard and screen reader users to bypass navigation and jump straight to the main content area (`#main-content`). The link is visually hidden by default and becomes visible only when focused, following existing site patterns.
2.  **Global Focus Indicators**: Implemented site-wide `:focus-visible` styles using the project's `--gold-light` design token. This ensures that keyboard users have a clear, high-contrast visual indicator of where they are on the page, enhancing the navigation experience without affecting mouse users.

These changes are well under the 50-line limit and ensure the site meets basic accessibility standards for keyboard navigation.

♿ **Accessibility**:
- Complies with WCAG 2.1 Success Criterion 2.4.1 (Bypass Blocks).
- Complies with WCAG 2.1 Success Criterion 2.4.7 (Focus Visible).

---
*PR created automatically by Jules for task [9071648484629207096](https://jules.google.com/task/9071648484629207096) started by @sweeden-ttu*