### PR TITLE
🎨 Palette: Add Skip to Content Link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -145,6 +145,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <!-- Google Tag Manager (noscript) -->
   {% if site.gtm_container_id and site.gtm_container_id != "GTM-XXXXXXX" %}
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.gtm_container_id }}"

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -31,7 +31,7 @@ body {
 }
 
 .skip-link {
-  position: absolute;
+  position: fixed;
   top: -40px;
   left: 1rem;
   background: var(--navy-dark);
@@ -44,6 +44,7 @@ body {
 
 .skip-link:focus {
   top: 1rem;
+  z-index: 1001;
 }
 
 .sr-only {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -31,7 +31,7 @@ body {
 }
 
 .skip-link {
-  position: absolute;
+  position: fixed;
   top: -40px;
   left: 1rem;
   background: var(--navy-dark);
@@ -44,6 +44,7 @@ body {
 
 .skip-link:focus {
   top: 1rem;
+  z-index: 1001;
 }
 
 .sr-only {

--- a/test_cases/skip-link.spec.ts
+++ b/test_cases/skip-link.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('Skip to Content link is present and works', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4000/');
+
+  const skipLink = page.locator('a.skip-link');
+  await expect(skipLink).toBeAttached();
+  await expect(skipLink).toHaveAttribute('href', '#main-content');
+  await expect(skipLink).toHaveText('Skip to content');
+
+  // Verify it's initially hidden (off-screen)
+  const boundingBox = await skipLink.boundingBox();
+  expect(boundingBox.y).toBeLessThan(0);
+
+  // Focus the link and verify it's visible
+  await page.keyboard.press('Tab');
+  await page.waitForTimeout(300); // Wait for transition
+  const visibleBoundingBox = await skipLink.boundingBox();
+  expect(visibleBoundingBox.y).toBeGreaterThanOrEqual(0);
+
+  // Click the link and verify focus moves to main content
+  await skipLink.click();
+  const mainContent = page.locator('#main-content');
+  await expect(mainContent).toBeFocused();
+});


### PR DESCRIPTION
I added a "Skip to Content" link to the primary layout (`_layouts/default.html`) to improve keyboard and screen reader accessibility. I also updated the CSS to ensure the link remains visible above the sticky header when focused and added a dedicated Playwright test to verify the enhancement.

---
*PR created automatically by Jules for task [11760542601606753435](https://jules.google.com/task/11760542601606753435) started by @sweeden-ttu*